### PR TITLE
Add warning for WCAG SC 1.4.4 violations

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = (opts) => {
       return `--${typeParams.prefix || 'step'}-${step.step}: ${step.clamp};`
     }).join('\n')}`
 
-    typeScale.find(step => {
+    typeScale.some(step => {
       if (step.wcagViolation) {
         atRule.warn(
           result,
@@ -171,16 +171,16 @@ module.exports = (opts) => {
       }
     });
 
-    clampsParams.pairs = clampsParams.pairs.reduce(function (result, value, index, array) {
+    clampsParams.pairs = clampsParams.pairs.reduce(function (pairs, value, index, array) {
       if (index % 2 === 0)
-        result.push(array.slice(index, index + 2));
-      return result;
+      pairs.push(array.slice(index, index + 2));
+      return pairs;
     }, []);
 
     const clampScale = calculateClamps(clampsParams);
     const response = `${clampScale.map(step => {
       return `--${clampsParams.prefix || 'space'}-${step.label}: ${clampsParams.usePx ? step.clampPx : step.clamp};`
-    }).join('\n')}`
+    }).join('\n')}`;
 
     atRule.replaceWith(response);
 

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = (opts) => {
       if (!key || value === undefined) continue;
 
       if (paramKeys.includes(key)) {
-        typeParams[key] = value.value;
+        typeParams[key] = isNaN(typeParams[key]) ? value.value : Number(value.value);
       }
     }
 
@@ -50,8 +50,7 @@ module.exports = (opts) => {
 
     typeScale.find(step => {
       if (step.wcagViolation) {
-        atRule.warn(
-          result,
+        result.warn(
           `WCAG SC 1.4.4 violation for viewports ${step.wcagViolation.from}px to ${step.wcagViolation.to}px.`
         );
         return true;

--- a/index.js
+++ b/index.js
@@ -23,7 +23,8 @@ module.exports = (opts) => {
       positiveSteps: 0,
       negativeSteps: 0,
       relativeTo: 'viewport',
-      prefix: 'step'
+      prefix: 'step',
+      label: 'utopia'
     };
     const paramKeys = Object.keys(typeParams);
 
@@ -50,7 +51,8 @@ module.exports = (opts) => {
 
     typeScale.find(step => {
       if (step.wcagViolation) {
-        result.warn(
+        atRule.warn(
+          result,
           `WCAG SC 1.4.4 violation for viewports ${step.wcagViolation.from}px to ${step.wcagViolation.to}px.`
         );
         return true;

--- a/index.js
+++ b/index.js
@@ -24,7 +24,6 @@ module.exports = (opts) => {
       negativeSteps: 0,
       relativeTo: 'viewport',
       prefix: 'step',
-      label: 'utopia'
     };
     const paramKeys = Object.keys(typeParams);
 

--- a/index.js
+++ b/index.js
@@ -9,10 +9,10 @@ module.exports = (opts) => {
   const DEFAULTS = { minWidth: 320, maxWidth: 1240, minFontSize: 16, maxFontSize: 20 }
   const config = Object.assign(DEFAULTS, opts)
 
-  const typeScale = (atRule) => {
+  const typeScale = (atRule, result) => {
     const { nodes } = CSSValueParser(atRule.params);
     const params = nodes[0].nodes.filter(x => ['word', 'string'].includes(x.type) && x.value !== '{' && x.value !== '}');
-  
+
     const typeParams = {
       minWidth: config.minWidth,
       maxWidth: config.maxWidth,
@@ -31,25 +31,36 @@ module.exports = (opts) => {
       atRule.remove();
       return false;
     }
-  
+
     for (let index = 0; index < params.length; index = index + 2) {
       const element = params[index];
       const key = element.value;
       const value = params[index + 1];
       if (!key || value === undefined) continue;
-  
+
       if (paramKeys.includes(key)) {
         typeParams[key] = value.value;
       }
     }
-  
+
     const typeScale = calculateTypeScale(typeParams);
     const response = `${typeScale.map(step => {
       return `--${typeParams.prefix || 'step'}-${step.step}: ${step.clamp};`
     }).join('\n')}`
-  
+
+    typeScale.find(step => {
+      if (step.wcagViolation) {
+        atRule.warn(
+          result,
+          `WCAG SC 1.4.4 violation for viewports ${step.wcagViolation.from}px to ${step.wcagViolation.to}px.`
+        );
+        return true;
+      }
+      return false;
+    });
+
     atRule.replaceWith(response);
-  
+
     return false;
   }
 
@@ -104,7 +115,7 @@ module.exports = (opts) => {
     });
 
     const spaceScale = calculateSpaceScale(spaceParams);
-    
+
     const response = `${[...spaceScale.sizes, ...spaceScale.oneUpPairs, ...spaceScale.customPairs].map(step => {
       return `--${spaceParams.prefix || 'space'}-${step.label}: ${spaceParams.usePx ? step.clampPx : step.clamp};`
     }).join('\n')}`
@@ -122,7 +133,7 @@ module.exports = (opts) => {
       atRule.remove();
       return false;
     }
-  
+
     const clampsParams = {
       minWidth: config.minWidth,
       maxWidth: config.maxWidth,
@@ -160,19 +171,19 @@ module.exports = (opts) => {
       }
     });
 
-    clampsParams.pairs = clampsParams.pairs.reduce(function(result, value, index, array) {
+    clampsParams.pairs = clampsParams.pairs.reduce(function (result, value, index, array) {
       if (index % 2 === 0)
         result.push(array.slice(index, index + 2));
       return result;
     }, []);
-  
+
     const clampScale = calculateClamps(clampsParams);
     const response = `${clampScale.map(step => {
       return `--${clampsParams.prefix || 'space'}-${step.label}: ${clampsParams.usePx ? step.clampPx : step.clamp};`
     }).join('\n')}`
-  
+
     atRule.replaceWith(response);
-  
+
     return false;
   }
 
@@ -180,9 +191,9 @@ module.exports = (opts) => {
     postcssPlugin: 'utopia',
 
     AtRule: {
-      utopia: atRule => {
+      utopia: (atRule, { result }) => {
         if (atRule.params.startsWith('typeScale(')) {
-          return typeScale(atRule);
+          return typeScale(atRule, result);
         }
 
         if (atRule.params.startsWith('spaceScale(')) {

--- a/index.test.js
+++ b/index.test.js
@@ -2,10 +2,10 @@ const postcss = require('postcss')
 
 const plugin = require('./')
 
-async function run (input, output, opts = { }) {
+async function run (input, output, opts = { }, expectedWarnings = 0) {
   let result = await postcss([plugin(opts)]).process(input, { from: undefined })
   expect(result.css).toEqual(output)
-  expect(result.warnings()).toHaveLength(0)
+  expect(result.warnings()).toHaveLength(expectedWarnings)
 }
 
 // Type
@@ -83,6 +83,24 @@ it('generates nothing with empty config', async () => {
     `:root { @utopia typeScale(); }`,
     `:root { }`,
     { minWidth: 320, maxWidth: 1240 }
+  )
+})
+
+it('generates a type scale which violates WCAG SC 1.4.4', async () => {
+  await run(
+    `:root { @utopia typeScale({
+        minWidth: 320,
+        maxWidth: 1240,
+        minFontSize: 16,
+        maxFontSize: 48,
+        minTypeScale: 1.2,
+        maxTypeScale: 1.25,
+        positiveSteps: 5,
+        negativeSteps: 2,
+      }); }`,
+      `:root {--step-5: clamp(2.4883rem, 0.1694rem + 11.5947vi, 9.1553rem);--step-4: clamp(2.0736rem, 0.2473rem + 9.1315vi, 7.3242rem);--step-3: clamp(1.728rem, 0.291rem + 7.185vi, 5.8594rem);--step-2: clamp(1.44rem, 0.3104rem + 5.6478vi, 4.6875rem);--step-1: clamp(1.2rem, 0.313rem + 4.4348vi, 3.75rem);--step-0: clamp(1rem, 0.3043rem + 3.4783vi, 3rem);--step--1: clamp(0.8333rem, 0.2884rem + 2.7246vi, 2.4rem);--step--2: clamp(0.6944rem, 0.2682rem + 2.1314vi, 1.92rem); }`,
+      {},
+      1,
   )
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "postcss-utopia",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "postcss-utopia",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-utopia",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "PostCSS plugin to generate fluid typopgraphy and space scales",
   "keywords": [
     "postcss",


### PR DESCRIPTION
Plugin will display warnings when the WCAG check fails during type scale calculations. For example:

```plaintext
[WARN] [vite] [vite:css] WCAG SC 1.4.4 violation for viewports 988px to 2104px.
```

Note: Only one warning will be displayed per `typeScale` rule, rather than one for each step that fails the check. This differs from <https://utopia.fyi/type/calculator>, so if you would like it to be more in line with the website, let me know.

Also, during my testing, I ran into an issue where the check did not work. Casting the `params` to numbers before passing them to `calculateTypeScale` fixed that.